### PR TITLE
Ref routing category filter handler

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 	"fmt"
 
-	"github.com/google/uuid"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -72,12 +71,7 @@ func insertDefaultCategories() error {
 	categories := []string{"General", "Technology", "Sports", "Entertainment", "Health"}
 
 	for _, name := range categories {
-		id := uuid.New() // Generate a new UUID
-
-		_, err := Db.Exec(
-			"INSERT INTO categories (id, name) VALUES (?, ?) ON CONFLICT(name) DO NOTHING;",
-			id.String(), name,
-		)
+		_, err := Db.Exec(`INSERT INTO categories (name) VALUES (?) ON CONFLICT(name) DO NOTHING;`, name)
 		if err != nil {
 			return fmt.Errorf("failed to insert category %s: %w", name, err)
 		}

--- a/database/db.go
+++ b/database/db.go
@@ -68,7 +68,7 @@ func applyMigration() error {
 
 // Insert default categories into the database.
 func insertDefaultCategories() error {
-	categories := []string{"General", "Technology", "Sports", "Entertainment", "Health"}
+	categories := []string{"general", "technology", "sports", "entertainment", "health"}
 
 	for _, name := range categories {
 		_, err := Db.Exec(`INSERT INTO categories (name) VALUES (?) ON CONFLICT(name) DO NOTHING;`, name)

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -19,16 +19,15 @@ CREATE TABLE IF NOT EXISTS posts (
 );
 
 CREATE TABLE IF NOT EXISTS categories (
-    id TEXT PRIMARY KEY,
     name TEXT UNIQUE NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS post_categories (
     post_id TEXT NOT NULL,
-    category_id TEXT NOT NULL,
-    PRIMARY KEY (post_id, category_id),
+    category TEXT NOT NULL,
+    PRIMARY KEY (post_id, category),
     FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE,
-    FOREIGN KEY (category_id) REFERENCES categories(id)
+    FOREIGN KEY (category) REFERENCES categories(name)
 );
 
 CREATE TABLE IF NOT EXISTS comments (

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -157,30 +157,9 @@ func Index(w http.ResponseWriter, r *http.Request) {
 		posts = append(posts, post)
 	}
 
-	// fetch all categories to render to the create post form
-	categRows, categQueryErr := database.Db.Query(`SELECT id, name FROM categories`)
-	if categQueryErr != nil {
-		log.Printf("Error fetching categories: %v\n", categQueryErr)
-		http.Error(w, "Failed to fetch categories", http.StatusInternalServerError)
+	categories, getCategoriesErr := pkg.GetCategories(w)
+	if getCategoriesErr != nil {
 		return
-	}
-	defer categRows.Close()
-
-	var categories []struct {
-		Id   string
-		Name string
-	}
-	for categRows.Next() {
-		var category struct {
-			Id   string
-			Name string
-		}
-		err := categRows.Scan(&category.Id, &category.Name)
-		if err != nil {
-			log.Printf("Error scanning category: %v\n", err)
-			continue
-		}
-		categories = append(categories, category)
 	}
 
 	TemplateError := func(message string, err error) {

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -23,8 +23,6 @@ func Index(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queriedCategoryId := r.URL.Query().Get("category")
-
 	if r.Method == http.MethodPost {
 		cookie, cookieErr := r.Cookie("session")
 		if cookieErr != nil {
@@ -130,11 +128,10 @@ func Index(w http.ResponseWriter, r *http.Request) {
 	SELECT p.id, p.title, p.content, p.image_url, p.created_at
 	FROM posts p
 	LEFT JOIN post_categories pc ON p.id = pc.post_id
-	WHERE ? = '' OR pc.category_id = ?
 	ORDER BY p.created_at DESC
 	`
 
-	rows, err := database.Db.Query(postsQuery, queriedCategoryId, queriedCategoryId)
+	rows, err := database.Db.Query(postsQuery)
 	if err != nil {
 		log.Printf("Error fetching posts: %v\n", err)
 		http.Error(w, "Failed to fetch posts", http.StatusInternalServerError)

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -99,8 +99,8 @@ func Index(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		for _, categoryId := range categories {
-			_, insertCategoriesErr := database.Db.Exec(`INSERT INTO post_categories (post_id, category_id) VALUES (?, ?)`, postId, categoryId)
+		for _, category := range categories {
+			_, insertCategoriesErr := database.Db.Exec(`INSERT INTO post_categories (post_id, category) VALUES (?, ?)`, postId, category)
 			if insertCategoriesErr != nil {
 				log.Printf("Error inserting selected categories to database: %v\n", insertCategoriesErr)
 				http.Error(w, "Failed to add categories", http.StatusInternalServerError)

--- a/handlers/posts/categoryposts.go
+++ b/handlers/posts/categoryposts.go
@@ -1,0 +1,14 @@
+package posts
+
+import (
+	"forum/handlers"
+	"net/http"
+)
+
+func CategoryPosts(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		handlers.ErrorPage(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+
+	// queriedCategoryId := r.URL.Query().Get("category")
+}

--- a/handlers/posts/categoryposts.go
+++ b/handlers/posts/categoryposts.go
@@ -1,8 +1,15 @@
 package posts
 
 import (
-	"forum/handlers"
+	"database/sql"
+	"log"
 	"net/http"
+	"strings"
+	"time"
+
+	"forum/database"
+	"forum/handlers"
+	"forum/pkg"
 )
 
 func CategoryPosts(w http.ResponseWriter, r *http.Request) {
@@ -10,5 +17,91 @@ func CategoryPosts(w http.ResponseWriter, r *http.Request) {
 		handlers.ErrorPage(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
 
-	// queriedCategoryId := r.URL.Query().Get("category")
+	queriedCategoryId := strings.TrimPrefix(r.URL.Path, "/posts/")
+
+	// rendering posts to template
+	type Post struct {
+		Id          string
+		Title       string
+		Content     string
+		ImagePath   string
+		CreatedTime time.Time
+	}
+
+	var posts []Post
+
+	postsQuery := `
+	SELECT DISTINCT p.id, p.title, p.content, p.image_url, p.created_at
+	FROM posts p
+	LEFT JOIN post_categories pc ON p.id = pc.post_id
+	WHERE ? = '' OR pc.category_id = ?
+	ORDER BY p.created_at DESC
+	`
+
+	rows, err := database.Db.Query(postsQuery, queriedCategoryId, queriedCategoryId)
+	if err != nil {
+		log.Printf("Error fetching posts: %v\n", err)
+		http.Error(w, "Failed to fetch posts", http.StatusInternalServerError)
+		return
+	}
+	defer rows.Close()
+
+	// populate the post struct
+	for rows.Next() {
+		var post Post
+		var imagePath sql.NullString // use sql.NullString to handle NULL values
+		err := rows.Scan(&post.Id, &post.Title, &post.Content, &imagePath, &post.CreatedTime)
+		if err != nil {
+			log.Printf("Error scanning post: %v\n", err)
+			continue
+		}
+
+		// if imagePath is valid, assign it to the post
+		if imagePath.Valid {
+			post.ImagePath = "../" + imagePath.String
+		}
+
+		posts = append(posts, post)
+	}
+
+	// fetch all categories to render to the create post form
+	categRows, categQueryErr := database.Db.Query(`SELECT id, name FROM categories`)
+	if categQueryErr != nil {
+		log.Printf("Error fetching categories: %v\n", categQueryErr)
+		http.Error(w, "Failed to fetch categories", http.StatusInternalServerError)
+		return
+	}
+	defer categRows.Close()
+
+	var categories []struct {
+		Id   string
+		Name string
+	}
+	for categRows.Next() {
+		var category struct {
+			Id   string
+			Name string
+		}
+		err := categRows.Scan(&category.Id, &category.Name)
+		if err != nil {
+			log.Printf("Error scanning category: %v\n", err)
+			continue
+		}
+		categories = append(categories, category)
+	}
+
+	TemplateError := func(message string, err error) {
+		http.Error(w, "Internal Server Error!", http.StatusInternalServerError)
+		log.Printf("%s: %v", message, err)
+	}
+
+	execTemplateErr := handlers.Templates.ExecuteTemplate(w, "categoryposts.html", map[string]interface{}{
+		"Posts":        posts,
+		"UserLoggedIn": pkg.UserLoggedIn(r),
+		"Categories":   categories,
+	})
+	if execTemplateErr != nil {
+		TemplateError("error executing template", execTemplateErr)
+		return
+	}
 }

--- a/handlers/posts/categoryposts.go
+++ b/handlers/posts/categoryposts.go
@@ -17,7 +17,7 @@ func CategoryPosts(w http.ResponseWriter, r *http.Request) {
 		handlers.ErrorPage(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
 
-	queriedCategoryId := strings.TrimPrefix(r.URL.Path, "/posts/")
+	queriedCategory := strings.TrimPrefix(r.URL.Path, "/posts/")
 
 	// rendering posts to template
 	type Post struct {
@@ -34,11 +34,11 @@ func CategoryPosts(w http.ResponseWriter, r *http.Request) {
 	SELECT DISTINCT p.id, p.title, p.content, p.image_url, p.created_at
 	FROM posts p
 	LEFT JOIN post_categories pc ON p.id = pc.post_id
-	WHERE ? = '' OR pc.category_id = ?
+	WHERE ? = '' OR pc.category = ?
 	ORDER BY p.created_at DESC
 	`
 
-	rows, err := database.Db.Query(postsQuery, queriedCategoryId, queriedCategoryId)
+	rows, err := database.Db.Query(postsQuery, queriedCategory, queriedCategory)
 	if err != nil {
 		log.Printf("Error fetching posts: %v\n", err)
 		http.Error(w, "Failed to fetch posts", http.StatusInternalServerError)

--- a/handlers/posts/categoryposts.go
+++ b/handlers/posts/categoryposts.go
@@ -64,30 +64,9 @@ func CategoryPosts(w http.ResponseWriter, r *http.Request) {
 		posts = append(posts, post)
 	}
 
-	// fetch all categories to render to the create post form
-	categRows, categQueryErr := database.Db.Query(`SELECT id, name FROM categories`)
-	if categQueryErr != nil {
-		log.Printf("Error fetching categories: %v\n", categQueryErr)
-		http.Error(w, "Failed to fetch categories", http.StatusInternalServerError)
+	categories, getCategoriesErr := pkg.GetCategories(w)
+	if getCategoriesErr != nil {
 		return
-	}
-	defer categRows.Close()
-
-	var categories []struct {
-		Id   string
-		Name string
-	}
-	for categRows.Next() {
-		var category struct {
-			Id   string
-			Name string
-		}
-		err := categRows.Scan(&category.Id, &category.Name)
-		if err != nil {
-			log.Printf("Error scanning category: %v\n", err)
-			continue
-		}
-		categories = append(categories, category)
 	}
 
 	TemplateError := func(message string, err error) {

--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 	http.HandleFunc("/", handlers.Index)
 	http.HandleFunc("/login", middlewares.RedirectIfLoggedIn(handlers.Login))
 	http.HandleFunc("/register", middlewares.RedirectIfLoggedIn(handlers.Register))
-	http.HandleFunc("/posts", posts.CategoryPosts)
+	http.HandleFunc("/posts/", posts.CategoryPosts)
 	http.HandleFunc("/api/vote", handlers.HandleVoteRequest)
 	http.HandleFunc("/logout", handlers.Logout)
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"forum/handlers/posts"
 	"forum/middlewares"
 
 	"forum/database"
@@ -54,6 +55,7 @@ func main() {
 	http.HandleFunc("/", handlers.Index)
 	http.HandleFunc("/login", middlewares.RedirectIfLoggedIn(handlers.Login))
 	http.HandleFunc("/register", middlewares.RedirectIfLoggedIn(handlers.Register))
+	http.HandleFunc("/posts", posts.CategoryPosts)
 	//http.HandleFunc("/api/vote", handlers.HandleVoteRequest(db))
 	http.HandleFunc("/logout", handlers.Logout)
 

--- a/pkg/getcategories.go
+++ b/pkg/getcategories.go
@@ -1,0 +1,41 @@
+package pkg
+
+import (
+	"log"
+	"net/http"
+
+	"forum/database"
+)
+
+type category struct {
+	Id   string
+	Name string
+}
+
+func GetCategories(w http.ResponseWriter) ([]category, error) {
+	// fetch all categories to render to the create post form
+	categRows, categQueryErr := database.Db.Query(`SELECT id, name FROM categories`)
+	if categQueryErr != nil {
+		log.Printf("Error fetching categories: %v\n", categQueryErr)
+		http.Error(w, "Failed to fetch categories", http.StatusInternalServerError)
+		return nil, categQueryErr
+	}
+	defer categRows.Close()
+
+	var categories []category
+
+	for categRows.Next() {
+		var category struct {
+			Id   string
+			Name string
+		}
+		err := categRows.Scan(&category.Id, &category.Name)
+		if err != nil {
+			log.Printf("Error scanning category: %v\n", err)
+			continue
+		}
+		categories = append(categories, category)
+	}
+
+	return categories, nil
+}

--- a/pkg/getcategories.go
+++ b/pkg/getcategories.go
@@ -14,7 +14,7 @@ type category struct {
 
 func GetCategories(w http.ResponseWriter) ([]category, error) {
 	// fetch all categories to render to the create post form
-	categRows, categQueryErr := database.Db.Query(`SELECT id, name FROM categories`)
+	categRows, categQueryErr := database.Db.Query(`SELECT name FROM categories`)
 	if categQueryErr != nil {
 		log.Printf("Error fetching categories: %v\n", categQueryErr)
 		http.Error(w, "Failed to fetch categories", http.StatusInternalServerError)
@@ -29,7 +29,7 @@ func GetCategories(w http.ResponseWriter) ([]category, error) {
 			Id   string
 			Name string
 		}
-		err := categRows.Scan(&category.Id, &category.Name)
+		err := categRows.Scan(&category.Name)
 		if err != nil {
 			log.Printf("Error scanning category: %v\n", err)
 			continue

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -267,6 +267,7 @@ align-items: center;
   color: white;
   font-size: 16px;
   font-weight: 300;
+  text-transform: capitalize;
 }
 
 .category-filters, .filter-option{
@@ -339,6 +340,7 @@ gap: 15px;
   gap: 10px;
   max-width: 100%;
   color: white;
+  text-transform: capitalize;
 }
 
 .form-row {

--- a/view/base.html
+++ b/view/base.html
@@ -182,7 +182,7 @@
           <textarea name="content" id="postContent" placeholder="Content" required></textarea>
           <div class="categories-container">
             {{ range .Categories }}
-            <input type="checkbox" id="category{{.Name}}" name="categories" value="{{ .Id }}" />
+            <input type="checkbox" id="category{{.Name}}" name="categories" value="{{ .Name }}" />
             {{.Name}}
             {{ end }}
           </div>

--- a/view/posts/categoryposts.html
+++ b/view/posts/categoryposts.html
@@ -182,7 +182,7 @@
           <textarea name="content" id="postContent" placeholder="Content" required></textarea>
           <div class="categories-container">
             {{ range .Categories }}
-            <input type="checkbox" id="category{{.Name}}" name="categories" value="{{ .Id }}" />
+            <input type="checkbox" id="category{{.Name}}" name="categories" value="{{ .Name }}" />
             {{.Name}}
             {{ end }}
           </div>

--- a/view/posts/categoryposts.html
+++ b/view/posts/categoryposts.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Forum</title>
+  <link rel="stylesheet" href="/static/css/base.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Monoton&display=swap" rel="stylesheet" />
+</head>
+
+<body class="{{ if .UserLoggedIn }}logged-in{{ end }}"
+  data-is-logged-in="{{ if .UserLoggedIn }}true{{ else }}false{{ end }}">
+  <div class="overlay" aria-hidden="true"></div>
+
+  <div class="container">
+    <!--Left sidebar-->
+    <aside class="right-sidebar" aria-label="Filters and Categories">
+      <section class="logo">
+        <div class="recommendations">
+          <div class="app-icon"></div>
+          <h1 class="monoton-regular">Forum</h1>
+        </div>
+      </section>
+
+      <nav class="about-section">
+        <h2>Filters</h2>
+        <div class="filters">
+          <div class="category-filters">
+            <h3>Categories</h3>
+            {{range .Categories}}
+            <a href="#" class="filter-option category-filter">{{.Name}}</a>
+            {{end}}
+          </div>
+        </div>
+
+        {{ if .UserLoggedIn }}
+        <a class="filter-option" href="#">My Posts</a>
+        <a class="filter-option" href="#">Liked Posts</a>
+        {{end}}
+      </nav>
+    </aside>
+
+    <!--Main  content-->
+    <main class="content-section" aria-label="Main Content">
+      <section class="search-bar" aria-label="Create new post">
+        <div class="user-avatar"></div>
+        <input type="text" placeholder="What's on your mind? " class="post-input" onclick="handleCreatePost()" readonly
+          aria-label="Click to create new post" />
+      </section>
+
+      <!--Posts Feed-->
+      <section class="posts-container" aria-label="Posts feed">
+        <!--sample post-->
+        {{ range .Posts }}
+        <article class="post" aria-labelledby="post-title-1">
+          <header class="post-header">
+            <div class="user-info">
+              <div class="header">
+                <div class="user-avatar"></div>
+                <span class="username">username</span>
+              </div>
+              <time class="post-time" datetime="2023-11-30T11:30">{{ .CreatedTime }}</time>
+            </div>
+          </header>
+
+          <h2 class="post-title">{{ .Title }}</h2>
+
+          <figure class="post-image">
+            <img src="{{ .ImagePath }}" alt="Post Image" />
+          </figure>
+
+          <div class="post-content">
+            <p class="post-content">{{ .Content }}</p>
+          </div>
+
+          <!--Post Actions-->
+          <section id="post-a">
+            <div class="post-actions">
+              <!--Like button-->
+              <button class="like-btn">
+                <svg class="icon" viewBox="0 0 24 24">
+                  <path d="M0 0h24v24H0z" fill="none" />
+                  <path
+                    d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.92 7 8.42 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-1.91l-.01-.01L23 10z" />
+                </svg>
+                Like (<span class="like-count"></span>)
+              </button>
+
+              <!--Dislike button-->
+              <button class="dislike-btn">
+                <svg class="icon" viewBox="0 0 24 24">
+                  <path d="M0 0h24v24H0z" fill="none" />
+                  <path
+                    d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v1.91l.01.01L1 14c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z" />
+                </svg>
+                Dislike (<span class="dislike-count"></span>)
+              </button>
+
+              <!--Comment button-->
+              <button class="comment-btn" aria-expanded="false">
+                <svg class="icon" viewBox="0 0 24 24">
+                  <path d="M21.99 4c0-1.1-.89-2-1.99-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4-.01-16z" />
+                </svg>
+                Comment (<span class="comment-count">2</span>)
+              </button>
+            </div>
+
+            <!--Add comment section-->
+            <section class="add-comment-section">
+              <input type="text" id="new-comment-text" placeholder="Add a comment" />
+              <button id="add-comment-btn">Comment</button>
+            </section>
+
+            <!--Comments section-->
+            <section class="comments-section" style="display: none">
+              <!--comment-->
+              <div class="comment">
+                <p>This is a comment on the post</p>
+                <div class="comment-actions">
+                  <!--Like button -->
+                  <button class="comment-like-btn">
+                    <svg class="icon" viewBox="0 0 24 24">
+                      <path d="M0 0h24v24H0z" fill="none" />
+                      <path
+                        d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.59 7.59C7.22 7.92 7 8.42 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-1.91l-.01-.01L23 10z" />
+                    </svg>
+                    (<span class="comment-like-count">0</span>)
+                  </button>
+
+                  <!--Dislike button-->
+                  <button class="comment-dislike-btn">
+                    <svg class="icon" viewBox="0 0 24 24">
+                      <path d="M0 0h24v24H0z" fill="none" />
+                      <path
+                        d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v1.91l.01.01L1 14c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z" />
+                    </svg>
+                    (<span class="comment-dislike-count">0</span>)
+                  </button>
+                </div>
+              </div>
+            </section>
+          </section>
+        </article>
+        {{ end }}
+      </section>
+    </main>
+
+    <!--right Sidebar-->
+    <aside class="left-sidebar">
+      <div class="user-account">
+        <div class="user-avatar"></div>
+        <div>
+          {{ if .UserLoggedIn }}
+          <div>@{{ .User.Username}}</div>
+          <form action="/logout" method="POST">
+            <button href="/logout" class="btn-primary" id="logout-btn">
+              Logout
+            </button>
+          </form>
+          {{else}}
+          <div>@Guest</div>
+          <a href="/login" class="btn-primary">Login</a>
+          {{end}}
+        </div>
+      </div>
+    </aside>
+
+    <!--Post modal: post creation-->
+    <!--Display post creation form if user is logged in-->
+    {{ if .UserLoggedIn }}
+    <dialog id="createPostOverlay" class="create-post-overlay" style="display: none">
+      <div id="createPostDiv" class="create-post-container">
+        <button class="close-create-post" onclick="closeCreatePostOverlay()">
+          &times;
+        </button>
+        <h2>Create a Post</h2>
+        <form action="/" method="POST" enctype="multipart/form-data" id="createPostForm">
+          <input name="title" type="text" id="postTitle" placeholder="Title" required />
+          <textarea name="content" id="postContent" placeholder="Content" required></textarea>
+          <div class="categories-container">
+            {{ range .Categories }}
+            <input type="checkbox" id="category{{.Name}}" name="categories" value="{{ .Id }}" />
+            {{.Name}}
+            {{ end }}
+          </div>
+          <div class="form-row">
+            <input type="file" name="image" id="postImage" accept="image/*" />
+            <button type="submit" class="submit-post-btn">Post</button>
+          </div>
+        </form>
+      </div>
+    </dialog>
+
+    {{ else }}
+    <!--Display login prompt if user is not logged in-->
+    <dialog id="loginPromptOverlay" class="create-post-overlay" style="display: none">
+      <div class="create-post-container login-prompt">
+        <h2>Please Login</h2>
+        <button class="close-create-post" onclick="closeLoginPromptOverlay()">
+          &times;
+        </button>
+        <p>You need to be logged in to perform this action.</p>
+        <a href="/login" class="btn-primary">Go to Login</a>
+      </div>
+    </dialog>
+    {{ end }}
+  </div>
+  <script src="/static/js/base.js"></script>
+  <script src="/static/js/post-actions.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
- Rendered all posts in `base html` instead of putting an option for filtering.
- Moved filter by categories to its function.
- Changed the database schema for `categories` to only have one unique column, `name`
- Changed the database schema for post categories to take `name` from categories instead of `category_id`.
- Added a function for getting categories from database to avoid repetition of the same functionality in more that one function.
- Changed all categories in `insertDefaultCategories` function to lowercase. This is essential when filtering posts with categories from the URL using the clause `...WHERE pc.category = ?`. If the categories are capitalized in the DB, the WHERE clause will always evaluate to false since the categories from the URL are retrieved in lowercase.