### PR TITLE
Reft routing category filter handler

### DIFF
--- a/controller/auth_test.go
+++ b/controller/auth_test.go
@@ -325,5 +325,4 @@ import "testing"
 // }
 
 func TestGenerateSession(t *testing.T) {
-
 }

--- a/database/db.go
+++ b/database/db.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 	"fmt"
 
-	"github.com/google/uuid"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -72,12 +71,7 @@ func insertDefaultCategories() error {
 	categories := []string{"General", "Technology", "Sports", "Entertainment", "Health"}
 
 	for _, name := range categories {
-		id := uuid.New() // Generate a new UUID
-
-		_, err := Db.Exec(
-			"INSERT INTO categories (id, name) VALUES (?, ?) ON CONFLICT(name) DO NOTHING;",
-			id.String(), name,
-		)
+		_, err := Db.Exec(`INSERT INTO categories (name) VALUES (?) ON CONFLICT(name) DO NOTHING;`, name)
 		if err != nil {
 			return fmt.Errorf("failed to insert category %s: %w", name, err)
 		}

--- a/database/db.go
+++ b/database/db.go
@@ -68,7 +68,7 @@ func applyMigration() error {
 
 // Insert default categories into the database.
 func insertDefaultCategories() error {
-	categories := []string{"General", "Technology", "Sports", "Entertainment", "Health"}
+	categories := []string{"general", "technology", "sports", "entertainment", "health"}
 
 	for _, name := range categories {
 		_, err := Db.Exec(`INSERT INTO categories (name) VALUES (?) ON CONFLICT(name) DO NOTHING;`, name)

--- a/database/db.go
+++ b/database/db.go
@@ -38,9 +38,9 @@ func InitializeDB() error {
 		return fmt.Errorf("failed to apply migrations: %w", err)
 	}
 
-	// Configure connection pool
-	Db.SetMaxOpenConns(1)
-	Db.SetMaxIdleConns(1)
+	// // Configure connection pool
+	// Db.SetMaxOpenConns(2)
+	// Db.SetMaxIdleConns(2)
 
 	return nil
 }

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -20,16 +20,15 @@ CREATE TABLE IF NOT EXISTS posts (
 );
 
 CREATE TABLE IF NOT EXISTS categories (
-    id TEXT PRIMARY KEY,
     name TEXT UNIQUE NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS post_categories (
     post_id TEXT NOT NULL,
-    category_id TEXT NOT NULL,
-    PRIMARY KEY (post_id, category_id),
+    category TEXT NOT NULL,
+    PRIMARY KEY (post_id, category),
     FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE,
-    FOREIGN KEY (category_id) REFERENCES categories(id)
+    FOREIGN KEY (category) REFERENCES categories(name)
 );
 
 CREATE TABLE IF NOT EXISTS comments (

--- a/handlers/error_test.go
+++ b/handlers/error_test.go
@@ -62,7 +62,7 @@ func TestErrorPage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(
 			tt.name, func(t *testing.T) {
-				var originalTemplateDir = templatesDir
+				originalTemplateDir := templatesDir
 				if tt.noTemplate {
 					templatesDir = ""
 					defer func() {

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -187,30 +187,9 @@ func Index(w http.ResponseWriter, r *http.Request) {
 	}
 	fmt.Printf(">>>>>>>>>>>%+v\n", posts) // Debugging output
 
-	// fetch all categories to render to the create post form
-	categRows, categQueryErr := database.Db.Query(`SELECT id, name FROM categories`)
-	if categQueryErr != nil {
-		log.Printf("Error fetching categories: %v\n", categQueryErr)
-		http.Error(w, "Failed to fetch categories", http.StatusInternalServerError)
+	categories, getCategoriesErr := pkg.GetCategories(w)
+	if getCategoriesErr != nil {
 		return
-	}
-	defer categRows.Close()
-
-	var categories []struct {
-		Id   string
-		Name string
-	}
-	for categRows.Next() {
-		var category struct {
-			Id   string
-			Name string
-		}
-		err := categRows.Scan(&category.Id, &category.Name)
-		if err != nil {
-			log.Printf("Error scanning category: %v\n", err)
-			continue
-		}
-		categories = append(categories, category)
 	}
 
 	TemplateError := func(message string, err error) {

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -3,13 +3,14 @@ package handlers
 import (
 	"database/sql"
 	"fmt"
-	"forum/controller"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
+
+	"forum/controller"
 
 	"forum/database"
 	"forum/pkg"

--- a/handlers/index.go
+++ b/handlers/index.go
@@ -24,7 +24,7 @@ func Index(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	queriedCategoryId := r.URL.Query().Get("category")
+	queriedCategory := r.URL.Query().Get("category")
 
 	if r.Method == http.MethodPost {
 		cookie, cookieErr := r.Cookie("session")
@@ -111,8 +111,8 @@ func Index(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		for _, categoryId := range categories {
-			_, insertCategoriesErr := database.Db.Exec(`INSERT INTO post_categories (post_id, category_id) VALUES (?, ?)`, postId, categoryId)
+		for _, category := range categories {
+			_, insertCategoriesErr := database.Db.Exec(`INSERT INTO post_categories (post_id, category) VALUES (?, ?)`, postId, category)
 			if insertCategoriesErr != nil {
 				log.Printf("Error inserting selected categories to database: %v\n", insertCategoriesErr)
 				http.Error(w, "Failed to add categories", http.StatusInternalServerError)
@@ -143,11 +143,11 @@ func Index(w http.ResponseWriter, r *http.Request) {
 	SELECT DISTINCT p.username , p.id, p.title, p.content, p.image_url, p.created_at
 	FROM posts p
 	LEFT JOIN post_categories pc ON p.id = pc.post_id
-	WHERE ? = '' OR pc.category_id = ?
+	WHERE ? = '' OR pc.category = ?
 	ORDER BY p.created_at DESC
 	`
 
-	rows, err := database.Db.Query(postsQuery, queriedCategoryId, queriedCategoryId)
+	rows, err := database.Db.Query(postsQuery, queriedCategory, queriedCategory)
 	if err != nil {
 		log.Printf("Error fetching posts: %v\n", err)
 		http.Error(w, "Failed to fetch posts", http.StatusInternalServerError)

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"forum/controller"
 	"io"
 	"log"
 	"net/http"
@@ -12,6 +11,8 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+
+	"forum/controller"
 
 	"forum/middlewares"
 

--- a/pkg/getcategories.go
+++ b/pkg/getcategories.go
@@ -1,13 +1,17 @@
 package pkg
+
 import (
 	"log"
 	"net/http"
+
 	"forum/database"
 )
+
 type category struct {
 	Id   string
 	Name string
 }
+
 func GetCategories(w http.ResponseWriter) ([]category, error) {
 	// fetch all categories to render to the create post form
 	categRows, categQueryErr := database.Db.Query(`SELECT name FROM categories`)

--- a/pkg/getcategories.go
+++ b/pkg/getcategories.go
@@ -1,0 +1,34 @@
+package pkg
+import (
+	"log"
+	"net/http"
+	"forum/database"
+)
+type category struct {
+	Id   string
+	Name string
+}
+func GetCategories(w http.ResponseWriter) ([]category, error) {
+	// fetch all categories to render to the create post form
+	categRows, categQueryErr := database.Db.Query(`SELECT id, name FROM categories`)
+	if categQueryErr != nil {
+		log.Printf("Error fetching categories: %v\n", categQueryErr)
+		http.Error(w, "Failed to fetch categories", http.StatusInternalServerError)
+		return nil, categQueryErr
+	}
+	defer categRows.Close()
+	var categories []category
+	for categRows.Next() {
+		var category struct {
+			Id   string
+			Name string
+		}
+		err := categRows.Scan(&category.Id, &category.Name)
+		if err != nil {
+			log.Printf("Error scanning category: %v\n", err)
+			continue
+		}
+		categories = append(categories, category)
+	}
+	return categories, nil
+}

--- a/pkg/getcategories.go
+++ b/pkg/getcategories.go
@@ -10,7 +10,7 @@ type category struct {
 }
 func GetCategories(w http.ResponseWriter) ([]category, error) {
 	// fetch all categories to render to the create post form
-	categRows, categQueryErr := database.Db.Query(`SELECT id, name FROM categories`)
+	categRows, categQueryErr := database.Db.Query(`SELECT name FROM categories`)
 	if categQueryErr != nil {
 		log.Printf("Error fetching categories: %v\n", categQueryErr)
 		http.Error(w, "Failed to fetch categories", http.StatusInternalServerError)
@@ -23,7 +23,7 @@ func GetCategories(w http.ResponseWriter) ([]category, error) {
 			Id   string
 			Name string
 		}
-		err := categRows.Scan(&category.Id, &category.Name)
+		err := categRows.Scan(&category.Name)
 		if err != nil {
 			log.Printf("Error scanning category: %v\n", err)
 			continue

--- a/pkg/userloggedin.go
+++ b/pkg/userloggedin.go
@@ -2,10 +2,11 @@ package pkg
 
 import (
 	"fmt"
-	"forum/database"
 	"log"
 	"net/http"
 	"time"
+
+	"forum/database"
 )
 
 func UserLoggedIn(r *http.Request) (bool, string) {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -299,6 +299,7 @@ align-items: center;
   color: white;
   font-size: 16px;
   font-weight: 300;
+  text-transform: capitalize;
 }
 
 .category-filters, .filter-option{
@@ -371,6 +372,7 @@ gap: 15px;
   gap: 10px;
   max-width: 100%;
   color: white;
+  text-transform: capitalize;
 }
 
 .form-row {

--- a/view/base.html
+++ b/view/base.html
@@ -68,9 +68,9 @@
 
           <h2 class="post-title">{{ .Title }}</h2>
           <div class="cat">
-            <!-- {{ range .Categories }}
+            {{/*<!-- {{ range .Categories }}
                 <span class="cat1">{{ .Name }}</span>
-            {{ end }} -->
+            {{ end }} -->*/}}
             <span class="cat1">Technology</span>
 
           </div>

--- a/view/base.html
+++ b/view/base.html
@@ -31,7 +31,7 @@
           <div class="category-filters">
             <h3>Categories</h3>
             {{range .Categories}}
-            <a href="#" class="filter-option category-filter">{{.Name}}</a>
+            <a href="?category={{ .Name }}" class="filter-option category-filter">{{.Name}}</a>
             {{end}}
           </div>
         </div>

--- a/view/base.html
+++ b/view/base.html
@@ -196,7 +196,7 @@
           <textarea name="content" id="postContent" placeholder="Content" required></textarea>
           <div class="categories-container">
             {{ range .Categories }}
-            <input type="checkbox" id="category{{.Name}}" name="categories" value="{{ .Id }}" />
+            <input type="checkbox" id="category{{.Name}}" name="categories" value="{{ .Name }}" />
             {{.Name}}
             {{ end }}
           </div>

--- a/view/base.html
+++ b/view/base.html
@@ -68,11 +68,9 @@
 
           <h2 class="post-title">{{ .Title }}</h2>
           <div class="cat">
-            {{/*<!-- {{ range .Categories }}
-                <span class="cat1">{{ .Name }}</span>
-            {{ end }} -->*/}}
-            <span class="cat1">Technology</span>
-
+            {{ range .Categories }}
+                <span class="cat1">{{ . }}</span>
+            {{ end }}
           </div>
 
           <figure class="post-image">


### PR DESCRIPTION
- Changed the database schema for categories to only have one unique column, name
- Changed the database schema for post categories to take name from categories instead of category_id.
- Added a function for getting categories from database to avoid repetition of the same functionality in more that one function.
- Changed all categories in `insertDefaultCategories` function to lowercase. This is essential when filtering posts with categories from the URL using the clause ...WHERE pc.category = ?. If the categories are capitalized in the DB, the WHERE clause will always evaluate to false since the categories from the URL are retrieved in lowercase.
- Linked category filters in `base html`.
- Rendered posts categories to post details.